### PR TITLE
Add AdminGetUserCommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Contains the following route:
 - auth/require-new-password --> Require new password when login with temporary password
 - auth/admin-create-user --> Admin create user
 - auth/admin-delete-user --> Admin delete user
+- auth/admin-get-user --> Admin get user
 - auth/list-users --> List users
 - auth/get-user --> Get user
 - auth/user --> Delete user

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -18,6 +18,7 @@ import { ConfirmForgotPasswordRequestDto } from './dto/confirmforgotpassword.req
 import { AdminDeleteUserRequestDto } from './dto/admindeleteuser.request.dto';
 import { ListUsersRequestDto } from './dto/listusers.request.dto';
 import { RequireNewPasswordRequestDto } from './dto/requirenewpassword.request.dto';
+import { AdminGetUserRequestDto } from './dto/admingetuser.request.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -135,6 +136,15 @@ export class AuthController {
   async listUsers(@Body() listUsersRequest: ListUsersRequestDto) {
     try {
       return await this.authService.listUsers(listUsersRequest);
+    } catch (e) {
+      throw new BadRequestException(e.message);
+    }
+  }
+
+  @Get('admin-get-user')
+  async adminGetUser(@Body() adminGetUserRequest: AdminGetUserRequestDto) {
+    try {
+      return await this.authService.adminGetUser(adminGetUserRequest);
     } catch (e) {
       throw new BadRequestException(e.message);
     }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -11,6 +11,7 @@ import { ConfirmForgotPasswordRequestDto } from './dto/confirmforgotpassword.req
 import { AdminDeleteUserRequestDto } from './dto/admindeleteuser.request.dto';
 import { ListUsersRequestDto } from './dto/listusers.request.dto';
 import { RequireNewPasswordRequestDto } from './dto/requirenewpassword.request.dto';
+import { AdminGetUserRequestDto } from './dto/admingetuser.request.dto';
 import {
   CognitoIdentityProviderClient,
   InitiateAuthCommand,
@@ -21,6 +22,7 @@ import {
   ChangePasswordCommand,
   GetUserCommand,
   AdminCreateUserCommand,
+  AdminGetUserCommand,
   ResendConfirmationCodeCommand,
   ConfirmForgotPasswordCommand,
   ListUsersCommand,
@@ -306,6 +308,26 @@ export class AuthService {
 
     try {
       const command = new ListUsersCommand(params);
+      const response = await this.client.send(command);
+      return response;
+    } catch (error) {
+      if (error.name !== '') {
+        return error.name;
+      }
+
+      // Handle other exceptions
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  async adminGetUser(adminGetUser: AdminGetUserRequestDto) {
+    const params = {
+      UserPoolId: this.userPoolId,
+      Username: adminGetUser.email,
+    };
+
+    try {
+      const command = new AdminGetUserCommand(params);
       const response = await this.client.send(command);
       return response;
     } catch (error) {

--- a/src/auth/dto/admingetuser.request.dto.ts
+++ b/src/auth/dto/admingetuser.request.dto.ts
@@ -1,0 +1,3 @@
+export class AdminGetUserRequestDto {
+  email: string;
+}


### PR DESCRIPTION
## Summary
- support AdminGetUserCommand to retrieve a user by admin
- expose `/auth/admin-get-user` endpoint
- document admin-get-user route

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_684020606a2c832996a69a363dcc42f2